### PR TITLE
Revert to virtualenv

### DIFF
--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -83,28 +83,16 @@
    "metadata": {}
   },
   {
-   "source": [
-    "Uninstall some pre-installed dependencies as they clash with the custom `berpublicsearch` package"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip uninstall -y datascience distributed requests tensorflow-probability"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install git+https://github.com/codema-dev/berpublicsearch"
+    "%%bash\n",
+    "pip install virtualenv\n",
+    "virtualenv berpublicsearch\n",
+    "source /content/berpublicsearch/bin/activate\n",
+    "pip install git+https://github.com/codema-dev/berpublicsearch"
    ]
   },
   {
@@ -134,6 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!source /content/berpublicsearch/bin/activate\n",
     "from berpublicsearch.flow import flow\n",
     "\n",
     "flow.run(\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,9 @@ authors = ["Rowan Molony <rowan.molony@codema.ie>"]
 [tool.poetry.dependencies]
 python = "^3.6.1 || ^3.7"
 tqdm = "^4.54.1"
-requests = "~2.23.0"
 prefect = "^0.13.19"
-dask = {extras = ["dataframe"], version = "^2"}
-pandas = "^1.1.5"
+dask = {extras = ["dataframe"], version = "^2020.12.0"}
+requests = "^2.25.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Tried conda to install resolve dependencies
on install BUT packages added by conda didnt
appear on PYTHONPATH as dasks submodules couldnt
access fsspec, virtualenv works IF oneline magic
via ! rather than %% is used to activate the
virtualenv for this cell; previously abandoned
virtualenv as local python variables didn't persist
into the bash %% cell in colab