### PR TITLE
Install berpublicsearch via pip

### DIFF
--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -207,7 +207,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !source /content/berpublicsearch_env/bin/activate\n",
     "# from berpublicsearch.read import read_berpublicsearch_txt\n",
     "# ber = read_berpublicsearch_txt(path_to_berpublicsearch_unzipped)"
    ]

--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -85,18 +85,6 @@
    "metadata": {}
   },
   {
-   "source": [
-    "`berpublicsearch` is installed in a `virtualenv` so that its packages do not conflict with natively installed `Google Colaboratory` Python packages\n",
-    "\n",
-    "**Note**: to access `berpublicsearch` it is necessary to activate the virtualenv each time at the top of the cell via \n",
-    "```bash\n",
-    "!source /content/dependencies/bin/activate\n",
-    "```"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -110,11 +98,7 @@
     }
    ],
    "source": [
-    "%%bash\n",
-    "pip install virtualenv\n",
-    "virtualenv berpublicsearch_env\n",
-    "source /content/berpublicsearch_env/bin/activate\n",
-    "pip install git+https://github.com/codema-dev/berpublicsearch"
+    "!pip install git+https://github.com/codema-dev/berpublicsearch"
    ]
   },
   {
@@ -145,7 +129,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!source /content/berpublicsearch_env/bin/activate\n",
     "from berpublicsearch.download import download_berpublicsearch\n",
     "\n",
     "download_berpublicsearch(email_address, path_to_berpublicsearch_zip)"
@@ -168,7 +151,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!source /content/berpublicsearch_env/bin/activate\n",
     "from berpublicsearch.convert import convert_to_parquet\n",
     "\n",
     "convert_to_parquet(path_to_berpublicsearch_unzipped, path_to_berpublicsearch_parquet)"


### PR DESCRIPTION
Now that prefect isn't a dependency can once again just install directly via pip