### PR TITLE
Add environment.yml for conda installs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: base
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - conda
+  - python=3.8
+  - geopandas
+  - poetry
+  - ipython
+  - requests
+  - dask
+  - pyarrow
+  - tqdm
+prefix: /home/wsl-rowanm/miniconda3


### PR DESCRIPTION
pyarrow requires a compiler and so installs more
easily via conda than pip, this yml file can
be used to perform a pure conda install via

`conda env create --file=environment.yml` and
`pip install .`