### PR TITLE
Split sandbox into setup-sandbox & sandbox

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,7 @@ dependencies:
   - dask
   - pyarrow
   - tqdm
+  - pre-commit
+  - jupyter
+  - jupyter_contrib_nbextensions
 prefix: /home/wsl-rowanm/miniconda3

--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run `setup-sandbox` first to download and convert `BER Public Search` to `parquet`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Experiment with the BER data in this `sandbox` environment\n",
+    "\n",
+    "Can now query the BER Public search data in this notebook using `dask`.  `dask` uses `pandas` under the hood but has the advantage of scaling to large data. \n",
+    "\n",
+    "If you are unfamiliar with `pandas` see:\n",
+    "- [Getting started](https://pandas.pydata.org/docs/getting_started/index.html#getting-started)\n",
+    "- [Community tutorials](https://pandas.pydata.org/docs/getting_started/tutorials.html?highlight=community) ... includes YouTube videos and interactive tutorials\n",
+    "\n",
+    "If you are familiar with `pandas` but new to `dask` see:\n",
+    "- [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html)\n",
+    "- [Community tutorials](https://docs.dask.org/en/latest/educational-resources.html?highlight=communitytutorials#educational-resources) ... includes YouTube videos and interactive tutorials\n",
+    "under the hood so if you are familiar with `pandas` using `dask` is straightforward "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "\n",
+    "save_directory = \"/content/drive/MyDrive/berpublicsearch\"\n",
+    "path_to_berpublicsearch_unzipped = f\"{save_directory}/BERPublicsearch\"\n",
+    "path_to_berpublicsearch_parquet = f\"{save_directory}/BERPublicsearch_parquet\"\n",
+    "\n",
+    "ber = dd.read_parquet(path_to_berpublicsearch_parquet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If above cell fails uncomment and run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from berpublicsearch.read import read_berpublicsearch_txt\n",
+    "# ber = read_berpublicsearch_txt(path_to_berpublicsearch_unzipped)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/setup-sandbox.ipynb
+++ b/notebooks/setup-sandbox.ipynb
@@ -1,17 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "To run this Notebook:\n",
+    "This `Jupyter Notebook` downloads the `BER Public search` dataset to your `Google Drive` and converts the data to `parquet` format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run it:\n",
     "\n",
     "- Register your email address with SEAI at https://ndber.seai.ie/BERResearchTool/Register/Register.aspx\n",
+    "\n",
     "- Run all cells by selecting `Runtime > Run All` from the dropdown menu\n",
-    "    - Enter your email address\n",
-    "    - (Google Colab) Authenticate `Google Drive` by clicking the URL linked below\n",
-    "- Skip to **Experiment with the BER data in this `sandbox` environment** to explore the `BERPublicsearch` data via `dask`\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+    "    - Enter your email address in the cell below\n",
+    "    - (Google Colab) Authenticate `Google Drive` by clicking the URL linked in the [Mount Google Drive](#mount-google-drive) section below"
+   ]
   },
   {
    "cell_type": "code",
@@ -23,13 +30,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Mount Google Drive\n",
     "\n",
     "... skip this section if not running in `Google Colab`"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -51,6 +58,7 @@
     "from os import path\n",
     "\n",
     "save_directory = \"/content/drive/MyDrive/berpublicsearch\"\n",
+    "\n",
     "if path.exists(save_directory):\n",
     "    print(f\"Skipping creation of new folder as {save_directory} already exists!\")\n",
     "else:\n",
@@ -58,13 +66,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# If running outside of `Google Colab`\n",
     "\n",
-    "... uncomment this section if running this notebook outside of Google Colab"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+    "... uncomment following cell"
+   ]
   },
   {
    "cell_type": "code",
@@ -78,25 +86,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Install Dependencies"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Process is interrupted.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!pip install git+https://github.com/codema-dev/berpublicsearch"
    ]
@@ -105,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Download `BERPublicsearch.zip` and convert to parquet \n",
+    "# Download `BERPublicsearch.zip` and convert to `parquet`\n",
     "\n",
     "`parquet` is used here inplace of the default `txt` format as it is:\n",
     "1. Compressed on disk: 184 MB vs 972 MB\n",
@@ -155,82 +155,6 @@
     "\n",
     "convert_to_parquet(path_to_berpublicsearch_unzipped, path_to_berpublicsearch_parquet)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Experiment with the BER data in this `sandbox` environment\n",
-    "\n",
-    "Can now query the BER Public search data in this notebook using `dask`.  `dask` uses `pandas` under the hood but has the advantage of scaling to large data. \n",
-    "\n",
-    "If you are unfamiliar with `pandas` see:\n",
-    "- [Getting started](https://pandas.pydata.org/docs/getting_started/index.html#getting-started)\n",
-    "- [Community tutorials](https://pandas.pydata.org/docs/getting_started/tutorials.html?highlight=community) ... includes YouTube videos and interactive tutorials\n",
-    "\n",
-    "If you are familiar with `pandas` but new to `dask` see:\n",
-    "- [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html)\n",
-    "- [Community tutorials](https://docs.dask.org/en/latest/educational-resources.html?highlight=communitytutorials#educational-resources) ... includes YouTube videos and interactive tutorials\n",
-    "under the hood so if you are familiar with `pandas` using `dask` is straightforward "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import dask.dataframe as dd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ber = dd.read_parquet(path_to_berpublicsearch_parquet)"
-   ]
-  },
-  {
-   "source": [
-    "If `convert_to_parquet` fails uncomment and run `read_berpublicsearch_txt` instead\n",
-    "\n",
-    "... reading from a `txt` file is slower than reading from `parquet` "
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# from berpublicsearch.read import read_berpublicsearch_txt\n",
-    "# ber = read_berpublicsearch_txt(path_to_berpublicsearch_unzipped)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ber.head()"
-   ]
-  },
-  {
-   "source": [],
-   "cell_type": "markdown",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -249,7 +173,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0-final"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Running the `setup-sandbox` notebook downloads and converts the
BER Public search dataset to GDrive by default
which can then be used in other exploratory notebooks such as `sandbox`

