### PR TITLE
Add instructions to RESTART RUNTIME

### DIFF
--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -71,7 +71,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now "
+    "Now you can query the `ber` object to explore the `BER Public search` dataset ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ber.head().compute()"
    ]
   },
   {

--- a/notebooks/setup.ipynb
+++ b/notebooks/setup.ipynb
@@ -15,9 +15,24 @@
     "\n",
     "- Register your email address with SEAI at https://ndber.seai.ie/BERResearchTool/Register/Register.aspx\n",
     "\n",
-    "- Run all cells by selecting `Runtime > Run All` from the dropdown menu\n",
-    "    - Enter your email address in the cell below\n",
-    "    - (Google Colab) Authenticate `Google Drive` by clicking the URL linked in the [Mount Google Drive](#mount-google-drive) section below"
+    "- Run the cell below to install all dependencies and select `RESTART RUNTIME` to register them\n",
+    "\n",
+    "- Run all cells by selecting `Runtime > Run All` from the dropdown menu and ...\n",
+    "    - Enter your email address\n",
+    "    - (Google Colab) Authenticate `Google Drive` by clicking the URL linked in the [Mount Google Drive](#mount-google-drive) section below\n",
+    "\n",
+    "- Once all cells have finished running you can query the converted `BER Public search` data saved on your `Google Drive` in ...\n",
+    "    - [sandbox](https://colab.research.google.com/github/codema-dev/berpublicsearch/blob/main/notebooks/sandbox.ipynb) ... includes links to tutorials\n",
+    "    - [heat-loss-parameter](https://colab.research.google.com/github/codema-dev/berpublicsearch/blob/main/notebooks/heat-loss-parameter.ipynb) ... an example application of this repository"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install git+https://github.com/codema-dev/berpublicsearch"
    ]
   },
   {
@@ -27,15 +42,6 @@
    "outputs": [],
    "source": [
     "email_address = input(\"Enter your email eddress: \")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Mount Google Drive\n",
-    "\n",
-    "... skip this section if not running in `Google Colab`"
    ]
   },
   {
@@ -83,22 +89,6 @@
     "# from os import getcwd\n",
     "\n",
     "# save_directory = getcwd()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Install Dependencies"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install git+https://github.com/codema-dev/berpublicsearch"
    ]
   },
   {
@@ -161,8 +151,8 @@
    "metadata": {},
    "source": [
     "# Now try ...\n",
-    "- [sandbox](https://colab.research.google.com/github/codema-dev/berpublicsearch/blob/main/notebooks/sandbox.ipynb)\n",
-    "- [heat-loss-parameter](https://colab.research.google.com/github/codema-dev/berpublicsearch/blob/main/notebooks/heat-loss-parameter.ipynb)"
+    "- [sandbox](https://colab.research.google.com/github/codema-dev/berpublicsearch/blob/main/notebooks/sandbox.ipynb) ... includes links to tutorials\n",
+    "- [heat-loss-parameter](https://colab.research.google.com/github/codema-dev/berpublicsearch/blob/main/notebooks/heat-loss-parameter.ipynb) ... an example application of this repository"
    ]
   }
  ],


### PR DESCRIPTION
`Google Colab` requires the runtime kernel to be
restarted "in order to use newly installed versions."
... i.e. the new versions of existing libraries such as
dask