### PR TITLE
Update README and Notebook usage guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ berpublicsearch
 
 The aim of this repository is to simplify working work with SEAI's BER Public search dataset
 
-... with the help of the open source `Python` software :code:`prefect`, :code:`dask` and :code:`requests`
+... with the help of the open source `Python` software :code:`dask` and :code:`requests`
 
 ... via:
 
@@ -60,27 +60,7 @@ Installation
 
 To setup the `berpublicsearch` sandbox:
 
-- Google Collab:
-
-    - Click the Google Collab badge & open `sandbox.ipynb`:
+- Click the Google Collab badge & open `setup.ipynb`:
     
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
-                :target: https://colab.research.google.com/github/codema-dev/berpublicsearch
-                
-    - Mount your Google Drive to your Google Collab instance & refresh your filetree
-
-        .. image:: images/mount-gdrive.jpg
-    
-    - Copy the path to your Google Drive data folder and paste it into the appropriate string
-
-        .. image:: images/copy-path.png
-
-    - For more information see `External data: Local Files, Drive, Sheets, and Cloud Storage`__
-    
-    __ https://colab.research.google.com/notebooks/io.ipynb
-
-- Local:
-    - Unzip the dataset
-    - Clone this repository locally via :code:`git clone https://github.com/codema-dev/berpublicsearch` 
-    - Launch `Jupyter Notebook` and open the relevant sandbox file in the `notebooks` folder 
-
+    .. image:: https://colab.research.google.com/assets/colab-badge.svg
+            :target: https://colab.research.google.com/github/codema-dev/berpublicsearch

--- a/notebooks/heat-loss-parameter.ipynb
+++ b/notebooks/heat-loss-parameter.ipynb
@@ -4,7 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Run `setup-sandbox` first to download and convert `BER Public Search` to `parquet`"
+    "# Run `setup.ipynb` first to download and convert `BER Public Search` to `parquet`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install geopandas seai_deap"
    ]
   },
   {

--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Run `setup-sandbox` first to download and convert `BER Public Search` to `parquet`"
+    "# Run `setup.ipynb` first to download and convert `BER Public Search` to `parquet`"
    ]
   },
   {

--- a/notebooks/setup.ipynb
+++ b/notebooks/setup.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "- Register your email address with SEAI at https://ndber.seai.ie/BERResearchTool/Register/Register.aspx\n",
     "\n",
-    "- Run the cell below to install all dependencies and select `RESTART RUNTIME` to register them\n",
+    "- Run the cell below to install all dependencies and (if prompted) select `RESTART RUNTIME` to register them\n",
     "\n",
     "- Run all cells by selecting `Runtime > Run All` from the dropdown menu and ...\n",
     "    - Enter your email address\n",


### PR DESCRIPTION
Remove instructions on local usage so only guide
on Google Colab

Install dependencies as required in notebooks instead
of via poetry for berpublicsearch