### PR TITLE
Add missing dependency for read_txt in sandbox

### DIFF
--- a/notebooks/heat-loss-parameter.ipynb
+++ b/notebooks/heat-loss-parameter.ipynb
@@ -452,7 +452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/sandbox.ipynb
+++ b/notebooks/sandbox.ipynb
@@ -63,6 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# !pip install git+https://github.com/codema-dev/berpublicsearch\n",
     "# from berpublicsearch.read import read_berpublicsearch_txt\n",
     "# ber = read_berpublicsearch_txt(path_to_berpublicsearch_unzipped)"
    ]

--- a/notebooks/setup.ipynb
+++ b/notebooks/setup.ipynb
@@ -68,27 +68,11 @@
     "if path.exists(save_directory):\n",
     "    print(f\"Skipping creation of new folder as {save_directory} already exists!\")\n",
     "else:\n",
-    "    mkdir(save_directory)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# If running outside of `Google Colab`\n",
-    "\n",
-    "... uncomment following cell"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# from os import getcwd\n",
-    "\n",
-    "# save_directory = getcwd()"
+    "    mkdir(save_directory)\n",
+    "    \n",
+    "path_to_berpublicsearch_zip = f\"{save_directory}/BERPublicsearch.zip\"\n",
+    "path_to_berpublicsearch_unzipped = f\"{save_directory}/BERPublicsearch\"\n",
+    "path_to_berpublicsearch_parquet = f\"{save_directory}/BERPublicsearch_parquet\""
    ]
   },
   {
@@ -100,17 +84,6 @@
     "`parquet` is used here inplace of the default `txt` format as it is:\n",
     "1. Compressed on disk: 184 MB vs 972 MB\n",
     "2. Siginficantly faster input speeds as it is read column-by-column rather than row-by-row"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path_to_berpublicsearch_zip = f\"{save_directory}/BERPublicsearch.zip\"\n",
-    "path_to_berpublicsearch_unzipped = f\"{save_directory}/BERPublicsearch\"\n",
-    "path_to_berpublicsearch_parquet = f\"{save_directory}/BERPublicsearch_parquet\""
    ]
   },
   {


### PR DESCRIPTION
Requires the berpublicsearch module to run and had
forgotten to pip install it before call